### PR TITLE
Detect and de-duplicate by execution id if available

### DIFF
--- a/data_retrieval/core.py
+++ b/data_retrieval/core.py
@@ -3,17 +3,60 @@ import gzip
 import datetime
 import os.path
 import csv
-from collections import Counter
+from collections import Counter, OrderedDict
 from sys import exit
 
 #Regexes for parsing
-is_valid_regex = re.compile("^\d{4}-\d{2}-\d{2}")
+is_valid_regex = re.compile("^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}")
 has_zero_results_regex = re.compile("Found 0 total results")
 query_regex = re.compile("(?<= search for ').*(?=' against .*wiki_content took)")
+execution_id_regex = re.compile("by executor (.{16})\.$")
 
 #File paths for output
 output_daily = "/a/aggregate-datasets/search/daily_pages/"
 output_single = "/a/aggregate-datasets/search/cirrus_query_aggregates.tsv"
+
+class BoundedRelatedStatCollector(object):
+  '''
+  Collects related log lines that occur within a provided timedelta of
+  another log line with the same group_by value.
+  '''
+  def __init__(self, callback, bounds=None):
+    self.data = OrderedDict()
+    self.callback = callback
+    self.bounds = bounds if bounds else datetime.timedelta(seconds=120)
+    self.visited = 0
+
+  def push(self, group_by, line, timestamp):
+    if group_by == None:
+      self.callback([line])
+      return
+
+    if group_by in self.data:
+      values, maxTimestamp = self.data[group_by]
+      # delete the key so it moves to the end of the list
+      del self.data[group_by]
+      values.append(line)
+      if timestamp > maxTimestamp:
+        maxTimestamp = timestamp
+    else:
+      values = [line]
+      maxTimestamp = timestamp
+
+    self.data[group_by] = (values, maxTimestamp)
+
+    self.visited += 1
+    if self.visited % 1000 == 0:
+      flush_up_to = maxTimestamp - self.bounds;
+      self.flush(flush_up_to)
+
+  def flush(self, max_timestamp=None):
+    for group_by in self.data:
+      values, timestamp = self.data[group_by]
+      if max_timestamp != None and timestamp > max_timestamp:
+        return
+      self.callback(values)
+      del self.data[group_by]
 
 #Construct a filepath
 def construct_filepath(date = None):
@@ -24,10 +67,22 @@ def construct_filepath(date = None):
   return path, date
 
 #Check if a line is even valid
-def is_valid(row):
-  if(re.search(is_valid_regex, row)):
-    return True
-  return False
+def extract_timestamp(row):
+  match = is_valid_regex.match(row)
+  if match:
+    try:
+      return datetime.datetime.strptime(match.group(), '%Y-%m-%d %I:%M:%S')
+    except ValueError:
+      return None
+  else:
+    return None
+
+def extract_execution_id(row):
+  match = execution_id_regex.search(row)
+  if match:
+    return match.group(1)
+  else:
+    return None
 
 #Check if a request returned zero results
 def is_zero(row):
@@ -64,19 +119,31 @@ def daily_write(date, zero_results):
 #If it has zero results, log the query to the query list and increment
 #the zero count.
 def parse_file(filename):
-  zero_result_count = 0;
-  zero_result_queries = list();
-  queries = 0;
+  stats = {
+    'queries': 0,
+    'zero_result_count': 0,
+    'zero_result_queries': list(),
+  }
+  def count_query(lines):
+    # Just assume whichever logline showed up last is the one we want
+    line = lines[-1]
+    stats['queries'] += 1
+    if is_zero(line):
+      stats['zero_result_count'] += 1
+      stats['zero_result_queries'].append(extract_query(line))
+
+  collector = BoundedRelatedStatCollector(count_query)
   connection = gzip.open(filename)
   for line in connection:
-    if(is_valid(line)):
-      queries +=1
-      if(is_zero(line)):
-        zero_result_count += 1
-        zero_result_queries.append(extract_query(line))
+    timestamp = extract_timestamp(line)
+    if timestamp != None:
+      execution_id = extract_execution_id(line)
+      collector.push(execution_id, line, timestamp)
   connection.close()
-  zero_result_queries = Counter(zero_result_queries)
-  return(queries, zero_result_count, zero_result_queries.most_common(100))
+  collector.flush()
+
+  zero_result_queries = Counter(stats['zero_result_queries'])
+  return(stats['queries'], stats['zero_result_count'], zero_result_queries.most_common(100))
 
 filepath, date = construct_filepath()
 query_count, zero_count, zero_results = parse_file(filepath)


### PR DESCRIPTION
Logs will now contain an id that uniquely identifies its
execution context. This is typically a single web request,
maintenance script run, and job run.

Log lines without an executor id will be processed as before.