### PR TITLE
Simplify executor id to number with 9+ digits

### DIFF
--- a/data_retrieval/core.py
+++ b/data_retrieval/core.py
@@ -12,7 +12,7 @@ from floccus import get
 #Regexes for parsing
 is_valid_regex = re.compile("^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}")
 has_zero_results_regex = re.compile("Found 0 total results")
-execution_id_regex = re.compile("by executor (.{16})\.$")
+execution_id_regex = re.compile("by executor (\d{9,})\.$")
 
 #File paths for output
 output_daily = "/home/ironholds/zero_results/"


### PR DESCRIPTION
While in code review the php code to generate these executor ids
ended up being simplified into a simple number, rather than a
16 character alphadecimal string.  This patch updates the dashboard
to match that new expectation.