### PR TITLE
Prod logs dont have a trailing period after executor

### DIFF
--- a/data_retrieval/core.py
+++ b/data_retrieval/core.py
@@ -12,7 +12,7 @@ from floccus import get
 #Regexes for parsing
 is_valid_regex = re.compile("^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}")
 has_zero_results_regex = re.compile("Found 0 total results")
-execution_id_regex = re.compile("by executor (\d{9,})\.$")
+execution_id_regex = re.compile("by executor (\d{9,})$")
 
 #File paths for output
 output_daily = "/home/ironholds/zero_results/"


### PR DESCRIPTION
Looks like i mucked this one up, the original patch had a period
at the end of the sentence but the final patch that made it into
prod no longer had that.

This patch adjusts the regex to detect the executor based on whats
really in the logs.