### PR TITLE
KPI sub-tabs #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Install the dependencies:
 $ R
 > install.packages(c("curl", "httpuv", "readr", "xts", "reshape2",
     "RColorBrewer", "shiny", "shinydashboard", "dygraphs", "markdown",
-    "ggplot2", "toOrdinal"))
+    "ggplot2", "toOrdinal", "scales"))
 ```
 
 Run the server:
@@ -14,6 +14,6 @@ Run the server:
 ```
 $ R
 > library(shiny)
-> runApp(launch.browser=0)
+> runApp(launch.browser = 0)
 ```
 

--- a/assets/content/kpi_api_usage.md
+++ b/assets/content/kpi_api_usage.md
@@ -1,0 +1,21 @@
+Key Performance Indicator: API usage
+=======
+
+We want people, both within our movement and outside it, to be able to easily access our information.
+
+Outages and inaccuracies
+------
+
+* None so far!
+
+Questions, bug reports, and feature suggestions
+------
+For technical, non-bug questions, [email Mikhail](mailto:mpopov@wikimedia.org?subject=Dashboard%20Question). If you experience a bug or notice something wrong, [create an issue on GitHub](https://github.com/Ironholds/rainbow/issues). If you have a suggestion, [open a ticket in Phabricator](https://phabricator.wikimedia.org/maniphest/task/create/) in the Discovery board or [email Dan](mailto:dgarry@wikimedia.org?subject=Dashboard%20Question).
+
+<hr style="border-color: gray;">
+<p style="font-size: small; color: gray;">
+  <strong>Link to this dashboard:</strong>
+  <a href="http://searchdata.wmflabs.org/metrics/#kpi_api_usage">
+    http://searchdata.wmflabs.org/metrics/#kpi_api_usage
+  </a>
+</p>

--- a/assets/content/kpi_load_time.md
+++ b/assets/content/kpi_load_time.md
@@ -1,0 +1,21 @@
+Key Performance Indicator: User-perceived load time
+=======
+
+If our search is fast and snappy, then more people will use it!
+
+Outages and inaccuracies
+------
+
+* None so far!
+
+Questions, bug reports, and feature suggestions
+------
+For technical, non-bug questions, [email Mikhail](mailto:mpopov@wikimedia.org?subject=Dashboard%20Question). If you experience a bug or notice something wrong, [create an issue on GitHub](https://github.com/Ironholds/rainbow/issues). If you have a suggestion, [open a ticket in Phabricator](https://phabricator.wikimedia.org/maniphest/task/create/) in the Discovery board or [email Dan](mailto:dgarry@wikimedia.org?subject=Dashboard%20Question).
+
+<hr style="border-color: gray;">
+<p style="font-size: small; color: gray;">
+  <strong>Link to this dashboard:</strong>
+  <a href="http://searchdata.wmflabs.org/metrics/#kpi_load_time">
+    http://searchdata.wmflabs.org/metrics/#kpi_load_time
+  </a>
+</p>

--- a/assets/content/kpi_zero_results.md
+++ b/assets/content/kpi_zero_results.md
@@ -1,0 +1,21 @@
+Key Performance Indicator: Zero results rate
+=======
+
+If a user gets zero results for their query, they’ve by definition not found what they’re looking for.
+
+Outages and inaccuracies
+------
+
+* None so far!
+
+Questions, bug reports, and feature suggestions
+------
+For technical, non-bug questions, [email Mikhail](mailto:mpopov@wikimedia.org?subject=Dashboard%20Question). If you experience a bug or notice something wrong, [create an issue on GitHub](https://github.com/Ironholds/rainbow/issues). If you have a suggestion, [open a ticket in Phabricator](https://phabricator.wikimedia.org/maniphest/task/create/) in the Discovery board or [email Dan](mailto:dgarry@wikimedia.org?subject=Dashboard%20Question).
+
+<hr style="border-color: gray;">
+<p style="font-size: small; color: gray;">
+  <strong>Link to this dashboard:</strong>
+  <a href="http://searchdata.wmflabs.org/metrics/#kpi_zero_results">
+    http://searchdata.wmflabs.org/metrics/#kpi_zero_results
+  </a>
+</p>

--- a/ui.R
+++ b/ui.R
@@ -10,16 +10,32 @@ header <- dashboardHeader(title = "Search & Discovery", disable = FALSE)
 sidebar <- dashboardSidebar(
   tags$head(
     tags$script("$(function() {
+    // Enables linking to specific tabs:
     if (window.location.hash){
       var hash = $.trim(window.location.hash);
       var tab = decodeURI(hash.substring(1, 100));
       $('a[data-value=\"'+tab+'\"]').click();
     }
+    // Enables clicking on a kpi summary value box to view the time series:
+    $('div[id^=kpi_summary_box_]').click(function(){
+        var parent_id = $(this).closest('div').attr('id');
+        var parent_target = parent_id.replace('_summary_box', '');
+        $('a[data-value=\"'+parent_target+'\"]').click();
+    });
+    // Visual feedback that the value box is now something you can click:
+    $('div[id^=kpi_summary_box_]').hover(function() {
+        $(this).css('cursor','pointer');
+    });
+    // Reveals the KPI dropdown menu at launch:
+    $('ul.sidebar-menu li.treeview').first().addClass('active');
   });")
   ),
   sidebarMenu(
-    menuItem(text = "KPIs", tabName = "kpis_summary",
-             badgeLabel = "new", badgeColor = "light-blue"),
+    menuItem(text = "KPIs",
+             menuSubItem(text = "Summary", tabName = "kpis_summary"),
+             menuSubItem(text = "Load times", tabName = "kpi_load_time"),
+             menuSubItem(text = "Zero results", tabName = "kpi_zero_results"),
+             menuSubItem(text = "API usage", tabName = "kpi_api_usage")),
     menuItem(text = "Desktop",
              menuSubItem(text = "Events", tabName = "desktop_events"),
              menuSubItem(text = "Load times", tabName = "desktop_load")),
@@ -54,13 +70,36 @@ body <- dashboardBody(
   tabItems(
     tabItem(tabName = "kpis_summary",
             htmlOutput("kpi_summary_date_range"),
-            fluidRow(valueBoxOutput("kpi_summary_load_time", width = 3),
-                     valueBoxOutput("kpi_summary_zero_results", width = 3),
-                     valueBoxOutput("kpi_summary_api_usage_all", width = 3),
+            fluidRow(valueBoxOutput("kpi_summary_box_load_time", width = 3),
+                     valueBoxOutput("kpi_summary_box_zero_results", width = 3),
+                     valueBoxOutput("kpi_summary_box_api_usage", width = 3),
                      valueBox(subtitle = "User-satisfaction", value = "WIP", color = "black", width = 3)),
             plotOutput("kpi_summary_api_usage_proportions", height = "30px"),
             includeMarkdown("./assets/content/kpis_summary.md")
             ),
+    tabItem(tabName = "kpi_load_time",
+            dygraphOutput("kpi_load_time_series"),
+            includeMarkdown("./assets/content/kpi_load_time.md")),
+    tabItem(tabName = "kpi_zero_results",
+            dygraphOutput("kpi_zero_results_series"),
+            includeMarkdown("./assets/content/kpi_zero_results.md")),
+    tabItem(tabName = "kpi_api_usage",
+            fluidRow(column(radioButtons("kpi_api_usage_series_data",
+                                         label = "Type of data to display",
+                                         choices = list("Calls" = "raw",
+                                                        "Day-to-day % change" = "change"),
+                                         inline = TRUE),
+                            width = 5),
+                     column(checkboxInput("kpi_api_usage_series_log_scale",
+                                          label = "Log10 Scale",
+                                          value = FALSE),
+                            width = 3),
+                     column(checkboxInput("kpi_api_usage_series_include_open",
+                                          label = "Include OpenSearch in total",
+                                          value = TRUE),
+                            width = 4)),
+            dygraphOutput("kpi_api_usage_series"),
+            includeMarkdown("./assets/content/kpi_api_usage.md")),
     tabItem(tabName = "desktop_events",
             fluidRow(
               valueBoxOutput("desktop_event_searches"),

--- a/ui.R
+++ b/ui.R
@@ -8,28 +8,7 @@ header <- dashboardHeader(title = "Search & Discovery", disable = FALSE)
 
 #Sidebar elements for the search visualisations.
 sidebar <- dashboardSidebar(
-  tags$head(
-    tags$script("$(function() {
-    // Enables linking to specific tabs:
-    if (window.location.hash){
-      var hash = $.trim(window.location.hash);
-      var tab = decodeURI(hash.substring(1, 100));
-      $('a[data-value=\"'+tab+'\"]').click();
-    }
-    // Enables clicking on a kpi summary value box to view the time series:
-    $('div[id^=kpi_summary_box_]').click(function(){
-        var parent_id = $(this).closest('div').attr('id');
-        var parent_target = parent_id.replace('_summary_box', '');
-        $('a[data-value=\"'+parent_target+'\"]').click();
-    });
-    // Visual feedback that the value box is now something you can click:
-    $('div[id^=kpi_summary_box_]').hover(function() {
-        $(this).css('cursor','pointer');
-    });
-    // Reveals the KPI dropdown menu at launch:
-    $('ul.sidebar-menu li.treeview').first().addClass('active');
-  });")
-  ),
+  tags$head(tags$script(src="rainbow.js")),
   sidebarMenu(
     menuItem(text = "KPIs",
              menuSubItem(text = "Summary", tabName = "kpis_summary"),

--- a/utils.R
+++ b/utils.R
@@ -5,6 +5,7 @@ library(reshape2)
 library(RColorBrewer)
 library(ggplot2)
 library(toOrdinal)
+library(scales) # for date_format function for ggplot2
 
 # library(grid) # for unit
 
@@ -101,6 +102,14 @@ gg_prop_bar <- function(data, cols) {
     geom_text(aes_string(label = cols$label,
                   y = "text_position",
                   x = 1))
+}
+
+# Calculates percent change either in `x` or from `x` to `y`
+percent_change <- function(x, y = NULL) {
+  if(is.null(y)) {
+    return(100 * (x - c(NA, x[-length(x)])) / c(NA, x[-length(x)]))
+  }
+  return(100 * (y - x) / x)
 }
 
 # It's fairly common to need to grab the last N [whatever] of values.

--- a/www/rainbow.js
+++ b/www/rainbow.js
@@ -1,0 +1,25 @@
+$(function() {
+
+    // Enables linking to specific tabs:
+    if (window.location.hash){
+      var hash = $.trim(window.location.hash);
+      var tab = decodeURI(hash.substring(1, 100));
+      $('a[data-value=\"'+tab+'\"]').click();
+    }
+
+    // Enables clicking on a kpi summary value box to view the time series:
+    $('div[id^=kpi_summary_box_]').click(function(){
+        var parent_id = $(this).closest('div').attr('id');
+        var parent_target = parent_id.replace('_summary_box', '');
+        $('a[data-value=\"'+parent_target+'\"]').click();
+    });
+
+    // Visual feedback that the value box is now something you can click:
+    $('div[id^=kpi_summary_box_]').hover(function() {
+        $(this).css('cursor','pointer');
+    });
+
+    // Reveals the KPI dropdown menu at launch:
+    $('ul.sidebar-menu li.treeview').first().addClass('active');
+
+});


### PR DESCRIPTION
Adds individual tabs for the three KPIs and makes it possible to click
on a KPI summary box in the summary tab to go into the detailed tab for
that KPI.

Update: all the JS code is now in an external file.